### PR TITLE
Use only major version numbers in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20


### PR DESCRIPTION
reduces the spam from dependabot by relying on semver being respected